### PR TITLE
🔧 Remove usage section from sqlserver README

### DIFF
--- a/sqlserver/README.md
+++ b/sqlserver/README.md
@@ -39,12 +39,6 @@ npm install
 npm run build
 ```
 
-## Usage
-
-```bash
-node dist/index.js "Server=localhost;Database=mydb;User Id=user;Password=pass;Encrypt=true;TrustServerCertificate=true;"
-```
-
 ## Available Tools
 
 1. **execute_query**: Executes SELECT queries


### PR DESCRIPTION
## 📝 Description
This PR addresses issue #2 by removing the "Usage" section from the sqlserver README.md file.

## 🎯 Changes Made
- ✅ Removed the entire "Usage" section from `sqlserver/README.md`
- ✅ Maintained proper markdown structure and formatting
- ✅ Kept all other sections intact and properly organized
- ✅ No broken links or references remain

## 📋 Acceptance Criteria Fulfilled
- [x] The usage section is completely removed from the sqlserver readme
- [x] The readme file maintains proper markdown formatting
- [x] No broken links or references remain after the removal

## 🔗 Related Issue
Fixes #2

## 📊 Impact
- Improved documentation structure by removing unnecessary section
- Cleaner and more focused README for the sqlserver MCP service
- Better alignment with documentation standards